### PR TITLE
Fixed crash issue due to WRITE_EXTERNAL_STORAGE permission.

### DIFF
--- a/filepicker/src/main/java/com/vincent/filepicker/activity/BaseActivity.java
+++ b/filepicker/src/main/java/com/vincent/filepicker/activity/BaseActivity.java
@@ -7,14 +7,9 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
-
 import com.vincent.filepicker.FolderListHelper;
 import com.vincent.filepicker.R;
-import com.vincent.filepicker.adapter.FolderListAdapter;
-import com.vincent.filepicker.filter.entity.Directory;
-
 import java.util.List;
-
 import pub.devrel.easypermissions.AfterPermissionGranted;
 import pub.devrel.easypermissions.AppSettingsDialog;
 import pub.devrel.easypermissions.EasyPermissions;
@@ -25,86 +20,92 @@ import pub.devrel.easypermissions.EasyPermissions;
  * Time: 16:21
  */
 
-public abstract class BaseActivity extends AppCompatActivity implements EasyPermissions.PermissionCallbacks {
-    private static final int RC_READ_EXTERNAL_STORAGE = 123;
-    private static final String TAG = BaseActivity.class.getName();
+public abstract class BaseActivity extends AppCompatActivity
+    implements EasyPermissions.PermissionCallbacks {
+  private static final int RC_READ_EXTERNAL_STORAGE = 123;
+  private static final String TAG = BaseActivity.class.getName();
 
-    protected FolderListHelper mFolderHelper;
-    protected boolean isNeedFolderList;
-    public static final String IS_NEED_FOLDER_LIST = "isNeedFolderList";
+  protected FolderListHelper mFolderHelper;
+  protected boolean isNeedFolderList;
+  public static final String IS_NEED_FOLDER_LIST = "isNeedFolderList";
 
-    abstract void permissionGranted();
+  abstract void permissionGranted();
 
-    @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
 
-        isNeedFolderList = getIntent().getBooleanExtra(IS_NEED_FOLDER_LIST, false);
-        if (isNeedFolderList) {
-            mFolderHelper = new FolderListHelper();
-            mFolderHelper.initFolderListView(this);
-        }
+    isNeedFolderList = getIntent().getBooleanExtra(IS_NEED_FOLDER_LIST, false);
+    if (isNeedFolderList) {
+      mFolderHelper = new FolderListHelper();
+      mFolderHelper.initFolderListView(this);
     }
+  }
 
-    @Override
-    protected void onPostCreate(@Nullable Bundle savedInstanceState) {
-        super.onPostCreate(savedInstanceState);
-        readExternalStorage();
+  @Override
+  protected void onPostCreate(@Nullable Bundle savedInstanceState) {
+    super.onPostCreate(savedInstanceState);
+    readExternalStorage();
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+      @NonNull int[] grantResults) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    // Forward results to EasyPermissions
+    EasyPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults, this);
+  }
+
+  /**
+   * Read external storage file
+   */
+  @AfterPermissionGranted(RC_READ_EXTERNAL_STORAGE)
+  private void readExternalStorage() {
+    boolean isGranted =
+        EasyPermissions.hasPermissions(this, "android.permission.READ_EXTERNAL_STORAGE",
+            "android.permission.WRITE_EXTERNAL_STORAGE");
+    if (isGranted) {
+      permissionGranted();
+    } else {
+      EasyPermissions.requestPermissions(this, getString(R.string.vw_rationale_storage),
+          RC_READ_EXTERNAL_STORAGE, "android.permission.READ_EXTERNAL_STORAGE",
+          "android.permission.WRITE_EXTERNAL_STORAGE");
     }
+  }
 
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        // Forward results to EasyPermissions
-        EasyPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults, this);
+  @Override
+  public void onPermissionsGranted(int requestCode, List<String> perms) {
+    Log.d(TAG, "onPermissionsGranted:" + requestCode + ":" + perms.size());
+    permissionGranted();
+  }
+
+  @Override
+  public void onPermissionsDenied(int requestCode, List<String> perms) {
+    Log.d(TAG, "onPermissionsDenied:" + requestCode + ":" + perms.size());
+    // If Permission permanently denied, ask user again
+    if (EasyPermissions.somePermissionPermanentlyDenied(this, perms)) {
+      new AppSettingsDialog.Builder(this).build().show();
+    } else {
+      finish();
     }
+  }
 
-    /**
-     * Read external storage file
-     */
-    @AfterPermissionGranted(RC_READ_EXTERNAL_STORAGE)
-    private void readExternalStorage() {
-        boolean isGranted = EasyPermissions.hasPermissions(this, "android.permission.READ_EXTERNAL_STORAGE");
-        if (isGranted) {
-            permissionGranted();
-        } else {
-            EasyPermissions.requestPermissions(this, getString(R.string.vw_rationale_storage),
-                    RC_READ_EXTERNAL_STORAGE, "android.permission.READ_EXTERNAL_STORAGE");
-        }
-    }
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
 
-    @Override
-    public void onPermissionsGranted(int requestCode, List<String> perms) {
-        Log.d(TAG, "onPermissionsGranted:" + requestCode + ":" + perms.size());
+    if (requestCode == AppSettingsDialog.DEFAULT_SETTINGS_REQ_CODE) {
+      // Do something after user returned from app settings screen, like showing a Toast.
+      if (EasyPermissions.hasPermissions(this, "android.permission.READ_EXTERNAL_STORAGE",
+          "android.permission.WRITE_EXTERNAL_STORAGE")) {
         permissionGranted();
-    }
-
-    @Override
-    public void onPermissionsDenied(int requestCode, List<String> perms) {
-        Log.d(TAG, "onPermissionsDenied:" + requestCode + ":" + perms.size());
-        // If Permission permanently denied, ask user again
-        if (EasyPermissions.somePermissionPermanentlyDenied(this, perms)) {
-            new AppSettingsDialog.Builder(this).build().show();
-        } else {
-            finish();
-        }
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-
-        if (requestCode == AppSettingsDialog.DEFAULT_SETTINGS_REQ_CODE) {
-            // Do something after user returned from app settings screen, like showing a Toast.
-            if (EasyPermissions.hasPermissions(this, "android.permission.READ_EXTERNAL_STORAGE")) {
-                permissionGranted();
-            } else {
-                finish();
-            }
-        }
-    }
-
-    public void onBackClick(View view) {
+      } else {
         finish();
+      }
     }
+  }
+
+  public void onBackClick(View view) {
+    finish();
+  }
 }


### PR DESCRIPTION
A fix for issue #50 .
Requested android.permission.WRITE_EXTERNAL_STORAGE permission along with android.permission.READ_EXTERNAL_STORAGE in BaseActivity, to prevent the crash, in devices running Android 7 and up while picking image through camera option. 